### PR TITLE
Caching boundary reader output

### DIFF
--- a/dnora/aux.py
+++ b/dnora/aux.py
@@ -497,3 +497,30 @@ def shift_spec(spec, D, shift=0):
         spec_shift = spec_shift[0]
 
     return spec_shift
+
+class CachedReaderMixin:
+    """
+    Utitility mixin for help with caching remote forcing data.
+    """
+    def get_filepath_if_cached(self, grid, url: str):
+        """
+        Returns the filepath if the file is cached locally, otherwise
+        hands back the URL.
+        """
+        maybe_cache = self._url_to_filename(grid, url)
+        if os.path.exists(maybe_cache):
+            return maybe_cache, True
+        else:
+            return url, False
+
+    def _url_to_filename(self, grid, url):
+        """
+        Sanitizes a url to a valid file name.
+        """
+        fname = grid.name + '_' + "".join(x for x in url if x.isalnum() or x == '.')
+        return os.path.join(self.cache_folder, fname)
+
+    def write_to_cache(self, ds, grid, url):
+        cache = self._url_to_filename(grid, url)
+        msg.plain(f'Caching {url} to {cache}')
+        ds.to_netcdf(cache)

--- a/dnora/bnd/pick.py
+++ b/dnora/bnd/pick.py
@@ -28,8 +28,11 @@ class TrivialPicker(PointPicker):
         return inds
 
 class NearestGridPoint(PointPicker):
-    """Choose the nearest grid point to each boundary point in the grid."""
-    def __init__(self):
+    """Choose the nearest grid point to each boundary point in the grid.
+    Set a maximum allowed distance using `max_dist` (in km) at instantiation time.
+    """
+    def __init__(self, max_dist=None):
+        self.max_dist = max_dist
         pass
 
     def __call__(self, grid, bnd_lon, bnd_lat):
@@ -41,8 +44,12 @@ class NearestGridPoint(PointPicker):
         inds = []
         for n in range(len(lat)):
             dx, ind = min_distance(lon[n], lat[n], bnd_lon, bnd_lat)
-            msg.plain(f"Point {n}: lat: {lat[n]:10.7f}, lon: {lon[n]:10.7f} <<< ({bnd_lat[ind]: .7f}, {bnd_lon[ind]: .7f}). Distance: {dx:.1f} km")
-            inds.append(ind)
+            ms = f"Point {n}: lat: {lat[n]:10.7f}, lon: {lon[n]:10.7f} <<< ({bnd_lat[ind]: .7f}, {bnd_lon[ind]: .7f}). Distance: {dx:.1f} km"
+            if self.max_dist is None or dx <= self.max_dist:
+                msg.plain(ms)
+                inds.append(ind)
+            else:
+                msg.plain('DISCARDED, too far: '+ms)
 
         inds = np.array(inds)
         return inds

--- a/dnora/bnd/read_metno.py
+++ b/dnora/bnd/read_metno.py
@@ -95,11 +95,22 @@ class WAM4km(BoundaryReader, CachedReaderMixin):
                         )[
                             ['SPEC', 'longitude', 'latitude', 'time', 'freq', 'direction']
                         ].copy()
-                    bnd_list.append(this_ds)
-                    self.write_to_cache(this_ds, grid, url)
+                    if (
+                        not bnd_list # always trust the first file that is read
+                        or ( # for the rest, check for consistency with first file
+                            (this_ds.longitude == bnd_list[0].longitude).all() and
+                            (this_ds.latitude  == bnd_list[0].latitude ).all()
+
+                        )):
+                        bnd_list.append(this_ds)
+                        if self.cache:
+                            self.write_to_cache(this_ds, url)
+                    else:
+                        msg.plain(f'SKIPPING, file inconsistent: {url}')
+
 
                 except OSError:
-                    msg.plain(f'FILE NOT FOUND, SKIPPING: {url}')
+                    msg.plain(f'SKIPPING, file not found: {url}')
 
 
         msg.info("Merging dataset together (this might take a while)...")

--- a/dnora/bnd/read_metno.py
+++ b/dnora/bnd/read_metno.py
@@ -103,8 +103,7 @@ class WAM4km(BoundaryReader, CachedReaderMixin):
 
                         )):
                         bnd_list.append(this_ds)
-                        if self.cache:
-                            self.write_to_cache(this_ds, url)
+                        self.write_to_cache(this_ds, url)
                     else:
                         msg.plain(f'SKIPPING, file inconsistent: {url}')
 

--- a/dnora/bnd/read_metno.py
+++ b/dnora/bnd/read_metno.py
@@ -16,13 +16,12 @@ from ..aux import day_list, create_time_stamps, CachedReaderMixin
 class WAM4km(BoundaryReader, CachedReaderMixin):
     def __init__(self, ignore_nan: bool=True, stride: int=6,
                  hours_per_file: int=73, last_file: str='', lead_time: int=0,
-                 cache: bool=True, clean_cache: bool=False) -> None:
+                 clean_cache: bool=False) -> None:
         self.ignore_nan = copy(ignore_nan)
         self.stride = copy(stride)
         self.hours_per_file = copy(hours_per_file)
         self.lead_time = copy(lead_time)
         self.last_file = copy(last_file)
-        self.cache = copy(cache)
         self.clean_cache = copy(clean_cache)
         self.cache_folder = 'dnora_bnd_temp'
         return
@@ -70,10 +69,9 @@ class WAM4km(BoundaryReader, CachedReaderMixin):
             for f in glob.glob(os.path.join(self.cache_folder, '*')):
                 os.remove(f)
 
-        if self.cache:
-            if not os.path.isdir(self.cache_folder):
-                os.mkdir(self.cache_folder)
-                print("Creating cache folder %s..." % cache_folder)
+        if not os.path.isdir(self.cache_folder):
+            os.mkdir(self.cache_folder)
+            print("Creating cache folder %s..." % cache_folder)
 
         start_times, end_times, file_times = create_time_stamps(start_time, end_time, stride = self.stride, hours_per_file = self.hours_per_file, last_file = self.last_file, lead_time = self.lead_time)
 
@@ -98,8 +96,7 @@ class WAM4km(BoundaryReader, CachedReaderMixin):
                             ['SPEC', 'longitude', 'latitude', 'time', 'freq', 'direction']
                         ].copy()
                     bnd_list.append(this_ds)
-                    if self.cache:
-                        self.write_to_cache(this_ds, grid, url)
+                    self.write_to_cache(this_ds, grid, url)
 
                 except OSError:
                     msg.plain(f'FILE NOT FOUND, SKIPPING: {url}')

--- a/dnora/wnd/read_metno.py
+++ b/dnora/wnd/read_metno.py
@@ -141,6 +141,24 @@ class NORA3(ForcingReader, CachedReaderMixin):
         url = 'https://thredds.met.no/thredds/dodsC/nora3/'+folder + '/' + filename
         return url
 
+    def get_filepath_if_cached(self, url: str):
+        """
+        Returns the filepath if the file is cached locally, otherwise
+        hands back the URL.
+        """
+        maybe_cache = self._url_to_filename(url)
+        if os.path.exists(maybe_cache):
+            return maybe_cache, True
+        else:
+            return url, False
+
+    def _url_to_filename(self, url):
+        """
+        Sanitizes a url to a valid file name.
+        """
+        fname = "".join(x for x in url if x.isalnum() or x == '.')
+        return os.path.join(self.cache_folder, fname)
+
 
 class MyWave3km(ForcingReader):
     """Reads wind data from the MyWave 3km hindcast directly from MET Norways

--- a/dnora/wnd/read_metno.py
+++ b/dnora/wnd/read_metno.py
@@ -112,7 +112,7 @@ class NORA3(ForcingReader, CachedReaderMixin):
                     msg.plain(f'Cached {url_or_cache} to {nc_fimex}')
                     wnd_list.append(xr.open_dataset(nc_fimex).squeeze())
                 except OSError:
-                    msg.plain(f'SKIPPING, error while treating: {url}')
+                    msg.plain(f'SKIPPING, error while treating: {url_or_cache}')
 
         wind_forcing = xr.concat(wnd_list, dim="time")
 


### PR DESCRIPTION
Hi, unsure if this is useful but I started implementing caching of the boundary spectra, the reason being that I've been running into missing files and changing coordinates on the met.no THREDDS (e.g., lon/lat are sometimes declared as coordinates, sometimes not), and downloading an entire year again because of a couple weird files isn't great.

I originally tried to insert a `class CachedBoundaryReader(BoundaryReader)` as an intermediary between `WAM4km` and `BoundaryReader` to make the caching available to all child classes, but gave up when it was getting too hacky because of all the `abstractmethod`s everywhere that make running `super` awkward.